### PR TITLE
verify marketing email

### DIFF
--- a/src/content/docs/learn/VerifyAccount.astro
+++ b/src/content/docs/learn/VerifyAccount.astro
@@ -74,7 +74,7 @@
                 x: ["duskfoundation", "autholykos", "theonlygamo", "davidvbenthem", "lf_dusk", "emadunk", "thisisryanking", "ayajeske", "fulviuus", "heindauven"],
                 discord: ["autholykos", "fulvio", "emanuelecarboni", "thisisryanking", "zer0.3445", "theonlygamo", "jadedoherty", "lufa23", "_david_vb", "ayajeske", "nortonandreev", "herr_seppia", "heindauven", "hdauven"],
                 telegram: ["autholykos", "jadedoherty", "maluca23", "ayajeske", "neotamandua", "emadunk", "venturfulvio", "reikashino", "thisisryanking", "theonlygamo", "hdauven", "herr_seppia", "therealfrznn"],
-                email: ["support@dusk.network", "contact@dusk.network", "emanuele@dusk.network", "ryan@dusk.network", "david@dusk.network", "jeske@dusk.network", "luca@dusk.network", "fulvio@dusk.network", "matteo@dusk.network", "jade@dusk.network", "carboni@dusk.network", "georgian@dusk.network"],
+                email: ["support@dusk.network", "marketing@dusk.network", "contact@dusk.network", "emanuele@dusk.network", "ryan@dusk.network", "david@dusk.network", "jeske@dusk.network", "luca@dusk.network", "fulvio@dusk.network", "matteo@dusk.network", "jade@dusk.network", "carboni@dusk.network", "georgian@dusk.network"],
             };
         }
 


### PR DESCRIPTION
[CHANGED]
- Updated verifyAccount.astro to verify marketing@dusk.network email