### PR TITLE
Add BEP20 DUSK bridge article

### DIFF
--- a/src/content/docs/developer/integrations/exchanges.md
+++ b/src/content/docs/developer/integrations/exchanges.md
@@ -171,7 +171,7 @@ To reinforce confidence in compliance, there is a comprehensive and detailed **l
 ### Token details
 
 - Token: `dusk`
-- Token decimals: `9` (18 decimals for ERC-20 / BEP-20 versions)
+- Token decimals: `9` (18 decimals for ERC20 / BEP20 versions)
 - [Tokenomics and metrics](https://docs.dusk.network/learn/tokenomics)
 - Consensus Mechanism: [Succinct Attestation Consensus](https://docs.dusk.network/learn/deep-dive/succinct-attestation)
 
@@ -193,12 +193,12 @@ Users are responsible for the fees of Binance Smart Chain and Ethereum.
 
 ### Token Migration
 
-Mainnet is now live, and users can still migrate from ERC-20 DUSK and BEP-20 DUSK to native DUSK by using the [migration contract](https://github.com/dusk-network/dusk-migration) to burn their tokens and release an equivalent amount of DUSK on the Dusk mainnet to the specified target address.
+Mainnet is now live, and users can still migrate from ERC20 DUSK and BEP20 DUSK to native DUSK by using the [migration contract](https://github.com/dusk-network/dusk-migration) to burn their tokens and release an equivalent amount of DUSK on the Dusk mainnet to the specified target address.
 
 More information about the Mainnet migration can be found [here](/learn/guides/mainnet-migration).
 
 Current token contracts are:
-- ERC-20 Contract Address: [0x940a2db1b7008b6c776d4faaca729d6d4a4aa551](https://etherscan.io/address/0x940a2db1b7008b6c776d4faaca729d6d4a4aa551)
-- BEP-20 Contract Address: [0xb2bd0749dbe21f623d9baba856d3b0f0e1bfec9c](https://bscscan.com/token/0xb2bd0749dbe21f623d9baba856d3b0f0e1bfec9c)
+- ERC20 Contract Address: [0x940a2db1b7008b6c776d4faaca729d6d4a4aa551](https://etherscan.io/address/0x940a2db1b7008b6c776d4faaca729d6d4a4aa551)
+- BEP20 Contract Address: [0xb2bd0749dbe21f623d9baba856d3b0f0e1bfec9c](https://bscscan.com/token/0xb2bd0749dbe21f623d9baba856d3b0f0e1bfec9c)
 
 The [migration contract](https://github.com/dusk-network/dusk-migration) has been [audited](https://github.com/dusk-network/audits/blob/main/core-audits/2024-10_migration-smart-contract-security-assessment_zellic.pdf) and user's can bridge to the Dusk mainnet via the [Dusk Web Wallet](https://wallet.dusk.network/).

--- a/src/content/docs/learn/guides/bep2-migration.md
+++ b/src/content/docs/learn/guides/bep2-migration.md
@@ -1,56 +1,10 @@
 ---
-title: Dusk BEP2 Migration
-description: Step-by-step guide to migrating your BEP2 DUSK tokens to the BEP20 standard.
+title: Dusk BEP2 Migration (Closed)
+description: The BEP2 to BEP20 DUSK migration has ended. This page is kept for transparency.
 ---
 
-As the <a href="https://www.bnbchain.org/en/blog/final-sunset-plan-of-bnb-beacon-chain" target="_blank">Binance Beacon Chain is sunsetting</a>, there have been multiple communications over the past months to facilitate the migration of BEP2 DUSK tokens to BEP20 DUSK.
+The DUSK BEP2 to BEP20 migration has officially concluded. The final deadline for users to submit their BEP2 tokens was **November 1st, 2024**, after which no further submissions were accepted. All valid migrations were processed, and the final distribution of BEP20 DUSK tokens was completed.
 
-This guide provides a step-by-step process for BEP2 DUSK token holders to successfully migrate their tokens.
+The migration wallet used during this period — `bnb1dfls6c8y39l7qq4gj2479wkehg85pt5m07y94g` — is no longer active and should not be used for any further transactions.
 
-
-:::note[Important]
-Users will have up to **November 1st** to migrate their BEP2 DUSK. We will no longer process any BEP2 afterwards! 
-
-All BEP2 DUSK migrated before that deadline will be processed after said date.
-:::
-
-## Why Migrate?
-
-The migration to BEP20 is crucial due to the sunsetting of the Binance Beacon Chain. Migrating ensures that your DUSK tokens remain usable, and can be bridge to mainnet in the future.
-
-## What You Will Need
-
-Before starting the migration process, please ensure you have:
-
-* A wallet holding your BEP2 DUSK tokens, with a small amount of BNB
-* A Binance Smart Chain-compatible wallet for receiving your BEP20 DUSK tokens (for example [BNB Chain Wallet](https://www.bnbchain.org/en/binance-wallet) or [Trust Wallet](https://trustwallet.com/).
-
-## Migration Process
-
-### Step 1: Gas
-
-Ensure that you have a small amount of BNB in your wallet to cover the network fees for the transaction.
-
-### Step 2: Sending BEP2 DUSK Tokens
-
-1. Access your wallet holding the BEP2 DUSK tokens. This can be done through the [BNB Chain Wallet](https://www.bnbchain.org/en/binance-wallet) or [Trust Wallet](https://trustwallet.com/).
-
-2. Initiate a transfer to our Dusk controlled migration wallet: `bnb1dfls6c8y39l7qq4gj2479wkehg85pt5m07y94g`
-
-:::danger
-**IMPORTANT**: In the MEMO field of the transaction, enter the receiving address of your BEP20-compatible wallet. **The address should be in a `0x` format**. This step is **crucial** to ensure your BEP20 DUSK tokens are sent to a correct address.
-:::
-
-![BNB Chain wallet transfer.](../../../../assets/bnb-chain-wallet.png)
-
-### Step 3: Receiving BEP20 DUSK Tokens 
-
-The Dusk team will process migrations in batches. Your BEP20 DUSK tokens will be distributed to the provided BEP20 wallet address on May the 1st 2024.
-
-## After Migration
-
-Dusk will make an announcement when the payout has been completed. Once you receive your BEP20, verify the receipt in your BEP20-compatible wallet.
-
-## Need Help?
-
-if you encounter any issues or have questions during the migration process, please reach out to us on our official [Telegram](https://t.me/DuskNetwork) or [Discord channel](https://discord.com/channels/847466263064346624/1223314872834588865).
+This page remains online for archival and transparency purposes only.

--- a/src/content/docs/learn/guides/bep20-bridge.md
+++ b/src/content/docs/learn/guides/bep20-bridge.md
@@ -1,0 +1,44 @@
+---
+title: Native DUSK to BEP20 Bridge
+description: How to bridge your native DUSK tokens to BEP20 DUSK on Binance Smart Chain.
+---
+
+This guide explains how to bridge your **native DUSK** tokens to **BEP20 DUSK** on Binance Smart Chain (BSC). This operation is handled through the official **BEP20 bridge** and facilitated via the [Dusk Web Wallet](https://apps.dusk.network/wallet/).
+
+When bridging, your native DUSK tokens are locked on the Dusk network. Once locked, a mint operation is initiated on Binance Smart Chain, issuing an equivalent amount of BEP20 DUSK to your specified address. The full bridging process typically completes within 15 minutes.
+
+:::note[Note]
+Want to **bridge from BEP20 DUSK to native DUSK** instead? Check our [Migration Guide](/learn/guides/mainnet-migration/) for the complete walkthrough.
+:::
+
+## Bridging Steps
+
+1. Open the [Web Wallet](https://apps.dusk.network/wallet/).
+2. Open or import your native Dusk wallet.
+3. Navigate to the **Send** tab.
+4. Enter the official **Bridge Address** as the recipient:
+```
+mFqH6RVxCoWQfjQ23H9YVr8JhQ697M5DD4ob76kcuoEYqqYA6H9cxHrxjvnZ6z4PQKsBd3PBpRYLN9M3FgkQQVywREzkzgeme4ersJgLaxYaQzZSAzkd1QBJ4ByTe9NrhXp
+```
+5. In the **Memo** field, enter your **BEP20 compatible address** (your BSC wallet address).
+6. Specify the amount of native DUSK to bridge. The minimum is 1.000000001 DUSK.
+7. Review and confirm the transaction.
+
+Your DUSK will be locked on the Dusk network, and an equivalent amount will be minted on BSC shortly after.
+
+## FAQ
+
+**How long does the bridge process take?**  
+Typically within 15 minutes. Network congestion or confirmations may slightly affect the timing.
+
+**Where do the BEP20 tokens go?**  
+They are sent to the EVM address specified in the memo field.
+
+**What happens if I omit the memo or use an invalid address?**  
+The bridge will ignore your transaction, and funds will not be bridged. Always double-check the memo field before confirming.
+
+**Can I use this bridge for ERC20 DUSK?**  
+No. This bridge only supports native DUSK to **BEP20 DUSK** on Binance Smart Chain.
+
+**Is there a fee?**  
+Yes, the bridge charges a flat fee of 1 DUSK per transaction. Your bridged amount will be **original amount - 1 DUSK**.

--- a/src/content/docs/learn/guides/bep20-bridge.md
+++ b/src/content/docs/learn/guides/bep20-bridge.md
@@ -21,7 +21,7 @@ Want to **bridge from BEP20 DUSK to native DUSK** instead? Check our [Migration 
 mFqH6RVxCoWQfjQ23H9YVr8JhQ697M5DD4ob76kcuoEYqqYA6H9cxHrxjvnZ6z4PQKsBd3PBpRYLN9M3FgkQQVywREzkzgeme4ersJgLaxYaQzZSAzkd1QBJ4ByTe9NrhXp
 ```
 5. In the **Memo** field, enter your **BEP20 compatible address** (your BSC wallet address).
-6. Specify the amount of native DUSK to bridge. The minimum is 1.000000001 DUSK.
+6. Specify the amount of native DUSK to bridge. The minimum is 1.000000001 DUSK (just over 1 DUSK).
 7. Review and confirm the transaction.
 
 Your DUSK will be locked on the Dusk network, and an equivalent amount will be minted on BSC shortly after.
@@ -35,7 +35,7 @@ Typically within 15 minutes. Network congestion or confirmations may slightly af
 They are sent to the EVM address specified in the memo field.
 
 **What happens if I omit the memo or use an invalid address?**  
-The bridge will ignore your transaction, and funds will not be bridged. Always double-check the memo field before confirming.
+The bridge will ignore your transaction, and funds will not be bridged. This means your funds would be lost. Always double-check the memo field before confirming.
 
 **Can I use this bridge for ERC20 DUSK?**  
 No. This bridge only supports native DUSK to **BEP20 DUSK** on Binance Smart Chain.

--- a/src/content/docs/learn/guides/erc20-staking.md
+++ b/src/content/docs/learn/guides/erc20-staking.md
@@ -1,13 +1,13 @@
 ---
-title: Withdraw staked ERC-20 DUSK
-description: Guide to reclaiming your DUSK from the ERC-20 staking contract used in ITN2.
+title: Withdraw staked ERC20 DUSK
+description: Guide to reclaiming your DUSK from the ERC20 staking contract used in ITN2.
 ---
 
 
-If you participated in the DUSK ERC-20 staking incentive program (ITN2), your DUSK remains safely stored in the ERC-20 staking smart contract. This guide walks you through the steps required to withdraw it manually using Etherscan.
+If you participated in the DUSK ERC20 staking incentive program (ITN2), your DUSK remains safely stored in the ERC20 staking smart contract. This guide walks you through the steps required to withdraw it manually using Etherscan.
 
 :::note[Note]
-This **only** applies to users who staked their DUSK using the ERC-20 staking portal for the ITN2 incentive program (which happened before Dusk mainnet launch).
+This **only** applies to users who staked their DUSK using the ERC20 staking portal for the ITN2 incentive program (which happened before Dusk mainnet launch).
 ::: 
 
 ---
@@ -62,7 +62,7 @@ You can then enter your Ethereum address and click **Query**, as this returns th
 
 ### Contract details
 
-- **ERC-20 Token Address:**  
+- **ERC20 Token Address:**  
   [0x940a2db1b7008b6c776d4faaca729d6d4a4aa551](https://etherscan.io/token/0x940a2db1b7008b6c776d4faaca729d6d4a4aa551)
 
 - **Staking Contract Address:**  

--- a/src/content/docs/learn/guides/mainnet-migration.md
+++ b/src/content/docs/learn/guides/mainnet-migration.md
@@ -1,6 +1,6 @@
 ---
-title: BEP-20/ER-C20 Migration
-description:  Detailed instructions for migrating your ERC-20/BEP-20 DUSK tokens to Dusk mainnet.
+title: BEP20/ERC20 Migration
+description:  Detailed instructions for migrating your ERC20/BEP20 DUSK tokens to Dusk mainnet.
 ---
 
 This guide provides instructions on how to migrate your BEP20/ERC20 DUSK tokens to native DUSK on the Dusk network. The migration process is facilitated through our [Web Wallet](https://apps.dusk.network/wallet/), allowing you to convert your tokens using WalletConnect-compatible Web3 wallets.

--- a/src/content/docs/learn/tokenomics.md
+++ b/src/content/docs/learn/tokenomics.md
@@ -5,7 +5,7 @@ description: Overview of Dusk’s tokenomics, allocation, vesting schedules, and
 
 ---
 
-The Dusk protocol utilizes the DUSK token both as an incentive for consensus participation and as its primary native currency. DUSK is currently represented as an ERC-20 or BEP-20 token. Since mainnet is now live, users are able to [migrate tokens to native DUSK](/learn/guides/mainnet-migration) via a burner contract.
+The Dusk protocol utilizes the DUSK token both as an incentive for consensus participation and as its primary native currency. DUSK is currently represented as an ERC20 or BEP20 token. Since mainnet is now live, users are able to [migrate tokens to native DUSK](/learn/guides/mainnet-migration) via a burner contract.
 
 This page provides an in-depth overview of the DUSK token’s metrics, utility, allocation, emission schedule, rewards, as well as insights from the <a href="https://github.com/dusk-network/audits/blob/main/core-audits/2024-09_protocol-security-review_oak-security.pdf">Economic Protocol Design</a> report.
 
@@ -13,7 +13,7 @@ This page provides an in-depth overview of the DUSK token’s metrics, utility, 
 
 - **Token Name**: Dusk
 - **Token Symbol**: DUSK
-- **Initial Supply**: 500,000,000 DUSK, comprising both ERC-20, BEP-20. These are migrated to native DUSK tokens using a burner contract.
+- **Initial Supply**: 500,000,000 DUSK, comprising both ERC20, BEP20. These are migrated to native DUSK tokens using a burner contract.
 - **Total Emitted Supply**: 500,000,000 DUSK will be emitted over 36 years to reward stakers on the mainnet, following the [Token Emission Schedule](#token-emission-schedule).
 - **Maximum Supply**: 1,000,000,000 DUSK, combining the 500M initial supply and 500M emitted over time.
 - **Circulating Supply**: Available on [this page](https://supply.dusk.network/). The circulating supply reflects the initial supply minus the DUSK held by the [Dusk deployer](https://etherscan.io/token/0x940a2db1b7008b6c776d4faaca729d6d4a4aa551?a=0x618bb3b255928ae6b2046df5c828fa1dc7e3c5f0). 

--- a/src/sidebars/defaultSidebar.js
+++ b/src/sidebars/defaultSidebar.js
@@ -31,7 +31,7 @@ const defaultSidebar = [
       { label: "Mainnet DUSK Migration", link: "/learn/guides/mainnet-migration/" },
       { label: "BEP20 Bridge", link: "/learn/guides/bep20-bridge/" },
       { label: "Restore Block Height", link: "/learn/guides/restore-height/" },
-      { label: "Withdraw staked ERC-20 DUSK", link: "/learn/guides/erc20-staking/" },
+      { label: "Withdraw staked ERC20 DUSK", link: "/learn/guides/erc20-staking/" },
       { label: "Verify Team Account", link: "learn/verify-team-account" },  
       { label: "Mainnet Onramp", link: "/learn/guides/dusk-mainnet-onramp/" },
       { label: "BEP2 Migration", link: "/learn/guides/bep2-migration/" },

--- a/src/sidebars/defaultSidebar.js
+++ b/src/sidebars/defaultSidebar.js
@@ -28,12 +28,13 @@ const defaultSidebar = [
     label: "Guides",
     items: [
       { label: "How to Stake", link: "/learn/guides/staking-basics/" },
-      { label: "Mainnet Onramp", link: "/learn/guides/dusk-mainnet-onramp/" },
       { label: "Mainnet DUSK Migration", link: "/learn/guides/mainnet-migration/" },
+      { label: "BEP20 Bridge", link: "/learn/guides/bep20-bridge/" },
       { label: "Restore Block Height", link: "/learn/guides/restore-height/" },
       { label: "Withdraw staked ERC-20 DUSK", link: "/learn/guides/erc20-staking/" },
-      { label: "BEP2 Migration", link: "/learn/guides/bep2-migration/" },
       { label: "Verify Team Account", link: "learn/verify-team-account" },  
+      { label: "Mainnet Onramp", link: "/learn/guides/dusk-mainnet-onramp/" },
+      { label: "BEP2 Migration", link: "/learn/guides/bep2-migration/" },
     ],
   },
   {


### PR DESCRIPTION
Resolves #57 

This PR:
- Adds docs about the native DUSK -> BEP20 bridge
- Standardizes use of BEP20 and ERC20
- Updates the BEP2 article
- Reorder the guide menu items under the learn section